### PR TITLE
xproperty and traitlets' allow_none

### DIFF
--- a/include/xwidgets/xbutton.hpp
+++ b/include/xwidgets/xbutton.hpp
@@ -16,7 +16,7 @@ namespace xeus
         xjson get_state() const;
         void apply_patch(const xjson& patch);
 
-        XPROPERTY(std::string, xbutton_style, button_color);
+        XPROPERTY(xt::xoptional<std::string>, xbutton_style, button_color);
         XPROPERTY(std::string, xbutton_style, font_weight);
 
     private:

--- a/include/xwidgets/xobject.hpp.orig
+++ b/include/xwidgets/xobject.hpp.orig
@@ -112,17 +112,26 @@ namespace xeus
 
         void send_patch(xjson&& state) const;
 
+<<<<<<< 13924ea0a04979ec3e1030828667b0bb31d6ce87
         xjson get_state() const;
         void apply_patch(const xjson& patch);
 
         void on_message(message_callback_type);
 
+        XPROPERTY(std::string, derived_type, _model_module);
+        XPROPERTY(std::string, derived_type, _model_module_version);
+        XPROPERTY(std::string, derived_type, _model_name);
+        XPROPERTY(std::string, derived_type, _view_module);
+        XPROPERTY(std::string, derived_type, _view_module_version);
+        XPROPERTY(std::string, derived_type, _view_name);
+=======
         XPROPERTY(xt::xoptional<std::string>, derived_type, _model_module);
         XPROPERTY(xt::xoptional<std::string>, derived_type, _model_module_version);
         XPROPERTY(xt::xoptional<std::string>, derived_type, _model_name);
         XPROPERTY(xt::xoptional<std::string>, derived_type, _view_module);
         XPROPERTY(xt::xoptional<std::string>, derived_type, _view_module_version);
         XPROPERTY(xt::xoptional<std::string>, derived_type, _view_name);
+>>>>>>> Expose all layout properties
 
     protected:
         

--- a/include/xwidgets/xslider.hpp
+++ b/include/xwidgets/xslider.hpp
@@ -16,7 +16,7 @@ namespace xeus
         xjson get_state() const;
         void apply_patch(const xjson& patch);
 
-        XPROPERTY(std::string, xslider_style, handle_color); // allow_none
+        XPROPERTY(xt::xoptional<std::string>, xslider_style, handle_color);
 
     private:
 

--- a/include/xwidgets/xwidget.hpp
+++ b/include/xwidgets/xwidget.hpp
@@ -33,31 +33,31 @@ namespace xeus
         xjson get_state() const;
         void apply_patch(const xjson& patch);
 
-        XPROPERTY(X_CASELESS_STR_ENUM(flex-start, flex-end, center, space-between, space-around, space-evenly, stretch, inherit, inital, unset), xlayout, align_content);
-        XPROPERTY(X_CASELESS_STR_ENUM(flex-start, flex-end, center, baseline, stretch, inherit, inital, unset), xlayout, align_items);
-        XPROPERTY(X_CASELESS_STR_ENUM(auto, flex-start, flex-end, center, baseline, stretch, inherit, inital, unset), xlayout, align_self);
-        XPROPERTY(std::string, xlayout, bottom);
-        XPROPERTY(std::string, xlayout, border);
-        XPROPERTY(std::string, xlayout, display);
-        XPROPERTY(std::string, xlayout, flex);
-        XPROPERTY(std::string, xlayout, flex_flow);
-        XPROPERTY(std::string, xlayout, height);
-        XPROPERTY(X_CASELESS_STR_ENUM(flex-start, flex-end, center, space-between, space-around, inherit, inital, unset), xlayout, justify_content);
-        XPROPERTY(std::string, xlayout, left);
-        XPROPERTY(std::string, xlayout, margin);
-        XPROPERTY(std::string, xlayout, max_height);
-        XPROPERTY(std::string, xlayout, max_width);
-        XPROPERTY(std::string, xlayout, min_height);
-        XPROPERTY(std::string, xlayout, min_width);
-        XPROPERTY(X_CASELESS_STR_ENUM(visible, hidden, scroll, auto, inherit, inital, unset), xlayout, overflow);
-        XPROPERTY(X_CASELESS_STR_ENUM(visible, hidden, scroll, auto, inherit, inital, unset), xlayout, overflow_x);
-        XPROPERTY(X_CASELESS_STR_ENUM(visible, hidden, scroll, auto, inherit, inital, unset), xlayout, overflow_y);
-        XPROPERTY(std::string, xlayout, order);
-        XPROPERTY(std::string, xlayout, padding);
-        XPROPERTY(std::string, xlayout, right);
-        XPROPERTY(std::string, xlayout, top);
-        XPROPERTY(std::string, xlayout, visibility);
-        XPROPERTY(std::string, xlayout, width);
+        XPROPERTY(xt::xoptional<X_CASELESS_STR_ENUM(flex-start, flex-end, center, space-between, space-around, space-evenly, stretch, inherit, inital, unset)>, xlayout, align_content);
+        XPROPERTY(xt::xoptional<X_CASELESS_STR_ENUM(flex-start, flex-end, center, baseline, stretch, inherit, inital, unset)>, xlayout, align_items);
+        XPROPERTY(xt::xoptional<X_CASELESS_STR_ENUM(auto, flex-start, flex-end, center, baseline, stretch, inherit, inital, unset)>, xlayout, align_self);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, bottom);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, border);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, display);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, flex);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, flex_flow);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, height);
+        XPROPERTY(xt::xoptional<X_CASELESS_STR_ENUM(flex-start, flex-end, center, space-between, space-around, inherit, inital, unset)>, xlayout, justify_content);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, left);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, margin);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, max_height);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, max_width);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, min_height);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, min_width);
+        XPROPERTY(xt::xoptional<X_CASELESS_STR_ENUM(visible, hidden, scroll, auto, inherit, inital, unset)>, xlayout, overflow);
+        XPROPERTY(xt::xoptional<X_CASELESS_STR_ENUM(visible, hidden, scroll, auto, inherit, inital, unset)>, xlayout, overflow_x);
+        XPROPERTY(xt::xoptional<X_CASELESS_STR_ENUM(visible, hidden, scroll, auto, inherit, inital, unset)>, xlayout, overflow_y);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, order);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, padding);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, right);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, top);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, visibility);
+        XPROPERTY(xt::xoptional<std::string>, xlayout, width);
 
     private:
 


### PR DESCRIPTION
Test use of `xt::xoptional` for traitlets' `allow_none`.

Also, this requires xtensor 0.10.10 or greater.