### PR TITLE
WIP Comm close in final widgets destructor

### DIFF
--- a/include/xwidgets/xbutton.hpp
+++ b/include/xwidgets/xbutton.hpp
@@ -40,6 +40,11 @@ namespace xeus
             this->open();
         }
 
+        ~button_style()
+        {
+            this->close();
+        }
+
         button_style(const button_style& other) : base_type(other)
         {
             this->open();
@@ -101,6 +106,11 @@ namespace xeus
         button() : base_type()
         {
             this->open();
+        }
+
+        ~button()
+        {
+            this->close();
         }
 
         button(const button& other) : base_type(other)

--- a/include/xwidgets/xslider.hpp
+++ b/include/xwidgets/xslider.hpp
@@ -39,6 +39,11 @@ namespace xeus
             this->open();
         }
 
+        ~slider_style()
+        {
+            this->close();
+        }
+
         slider_style(const slider_style& other) : base_type(other)
         {
             this->open();
@@ -105,6 +110,11 @@ namespace xeus
         slider() : base_type()
         {
             this->open();
+        }
+
+        ~slider()
+        {
+            this->close();
         }
 
         slider(const slider& other) : base_type(other)

--- a/include/xwidgets/xwidget.hpp
+++ b/include/xwidgets/xwidget.hpp
@@ -65,9 +65,14 @@ namespace xeus
             this->open();
         }
 
+        ~layout()
+        {
+            this->close();
+        }
+
         layout(const layout& other) : base_type(other)
         {
-           this->open();
+            this->open();
         }
 
         layout(layout&&) = default;


### PR DESCRIPTION
This should not be done in descructors or widgets that have been moved, just like the unregistration of comms in xeus.

Note that if we make `open` and `close` part of xcomm constructors and destructors, this will not be required, and final widgets will only need to make a call to `send_state`.