### PR TITLE
Fixup button value semantics

### DIFF
--- a/include/xwidgets/xbutton.hpp
+++ b/include/xwidgets/xbutton.hpp
@@ -62,20 +62,10 @@ namespace xeus
             this->open();
         }
 
-        button_style(button_style&& other) : base_type(std::move(other))
-        {
-        }
-
         button_style& operator=(const button_style& other)
         {
             base_type::operator=(other);
             this->open();
-            return *this;
-        }
-
-        button_style& operator=(button_style&& other)
-        {
-            base_type::operator=(std::move(other));
             return *this;
         }
     };
@@ -107,9 +97,10 @@ namespace xeus
         XPROPERTY(X_CASELESS_STR_ENUM(primary, success, info, warning, danger,), derived_type, button_style);
         XPROPERTY(::xeus::button_style, derived_type, style);
 
+        void handle_custom_message(const xjson&);
+
     private:
 
-        void handle_button_message(const xjson&);
         void set_defaults();
 
         std::list<click_callback_type> m_click_callbacks;
@@ -139,20 +130,10 @@ namespace xeus
             this->open();
         }
 
-        button(button&& other) : base_type(std::move(other))
-        {
-        }
-
         button& operator=(const button& other)
         {
             base_type::operator=(other);
             this->open();
-            return *this;
-        }
-
-        button& operator=(button&& other)
-        {
-            base_type::operator=(std::move(other));
             return *this;
         }
     };
@@ -204,7 +185,6 @@ namespace xeus
         : base_type()
     {
         set_defaults();
-        this->on_message(std::bind(&xbutton::handle_button_message, this, std::placeholders::_1));
     }
 
     template <class D>
@@ -251,7 +231,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xbutton<D>::handle_button_message(const xjson& content)
+    inline void xbutton<D>::handle_custom_message(const xjson& content)
     {
         auto it = content.find("event");
         if (it != content.end() && it.value() == "click")

--- a/include/xwidgets/xlayout.hpp
+++ b/include/xwidgets/xlayout.hpp
@@ -86,20 +86,10 @@ namespace xeus
             this->open();
         }
 
-        layout(layout&& other) : base_type(std::move(other))
-        {
-        }
-
         layout& operator=(const layout& other)
         {
             base_type::operator=(other);
             this->open();
-            return *this;
-        }
-
-        layout& operator=(layout&& other)
-        {
-            base_type::operator=(std::move(other));
             return *this;
         }
     };

--- a/include/xwidgets/xslider.hpp
+++ b/include/xwidgets/xslider.hpp
@@ -61,20 +61,10 @@ namespace xeus
             this->open();
         }
 
-        slider_style(slider_style&& other) : base_type(std::move(other))
-        {
-        }
-
         slider_style& operator=(const slider_style& other)
         {
             base_type::operator=(other);
             this->open();
-            return *this;
-        }
-
-        slider_style& operator=(slider_style&& other)
-        {
-            base_type::operator=(std::move(other));
             return *this;
         }
     };

--- a/include/xwidgets/xtransport.hpp
+++ b/include/xwidgets/xtransport.hpp
@@ -86,8 +86,6 @@ namespace xeus
         void send_patch(xjson&& state) const;
         void send(xjson&& content) const;
 
-        void on_message(message_callback_type);
-
     protected:
         
         bool moved_from() const noexcept;
@@ -257,12 +255,6 @@ namespace xeus
     }
 
     template <class D>
-    inline void xtransport<D>::on_message(message_callback_type cb)
-    {
-         m_message_callbacks.emplace_back(std::move(cb));
-    }
-
-    template <class D>
     inline bool xtransport<D>::moved_from() const noexcept
     {
          return m_moved_from;
@@ -307,7 +299,7 @@ namespace xeus
             auto it = data.find("content");
             if (it != data.end())
             {
-                handle_custom_message(it.value());
+                derived_cast().handle_custom_message(it.value());
             }
         }
     }
@@ -315,10 +307,6 @@ namespace xeus
     template <class D>
     inline void xtransport<D>::handle_custom_message(const xjson& content)
     {
-        for (auto it = m_message_callbacks.begin(); it != m_message_callbacks.end(); ++it)
-        {
-            it->operator()(content);
-        }
     }
 }
 


### PR DESCRIPTION
The base widget had a collection of callbacks for custom messages.

This collection was copied according to the value semantics of the base widget.

When the callback collection had methods of the current widget registered, it would still point to a member of the moved-from widget after a move.