### PR TITLE
widgets have now their own namespace

### DIFF
--- a/include/xwidgets/xboolean.hpp
+++ b/include/xwidgets/xboolean.hpp
@@ -11,7 +11,7 @@
 
 #include "xwidget.hpp"
 
-namespace xeus
+namespace xw
 {
 
     /*****************************
@@ -27,8 +27,8 @@ namespace xeus
         using derived_type = D;
 
         xboolean();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, description);
 
@@ -52,9 +52,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xboolean<D>::get_state() const
+    inline xeus::xjson xboolean<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(value, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(disabled, state);
@@ -63,7 +63,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xboolean<D>::apply_patch(const xjson& patch)
+    inline void xboolean<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xbox.hpp
+++ b/include/xwidgets/xbox.hpp
@@ -13,7 +13,7 @@
 #include "xmaterialize.hpp"
 #include "xwidget.hpp"
 
-namespace xeus
+namespace xw
 {
     /********************
      * xbox declaration *
@@ -29,8 +29,8 @@ namespace xeus
         using children_list = std::vector<xholder>;
 
         xbox();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(X_CASELESS_STR_ENUM(success, info, warning, danger,), derived_type, box_style);
         XPROPERTY(children_list, derived_type, children);
@@ -100,9 +100,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xbox<D>::get_state() const
+    inline xeus::xjson xbox<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(box_style, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(children, state);
@@ -111,7 +111,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xbox<D>::apply_patch(const xjson& patch)
+    inline void xbox<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xbutton.hpp
+++ b/include/xwidgets/xbutton.hpp
@@ -13,7 +13,7 @@
 #include "xstyle.hpp"
 #include "xwidget.hpp"
 
-namespace xeus
+namespace xw
 {
     /****************************
      * button_style declaration *
@@ -28,8 +28,8 @@ namespace xeus
         using derived_type = D;
 
         xbutton_style();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(XOPTIONAL(std::string), derived_type, button_color);
         XPROPERTY(std::string, derived_type, font_weight);
@@ -56,8 +56,8 @@ namespace xeus
         using derived_type = D;
 
         xbutton();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         void on_click(click_callback_type);
 
@@ -67,9 +67,9 @@ namespace xeus
         XPROPERTY(bool, derived_type, disabled);
         XPROPERTY(std::string, derived_type, icon);
         XPROPERTY(X_CASELESS_STR_ENUM(primary, success, info, warning, danger, ), derived_type, button_style);
-        XPROPERTY(::xeus::button_style, derived_type, style);
+        XPROPERTY(::xw::button_style, derived_type, style);
 
-        void handle_custom_message(const xjson&);
+        void handle_custom_message(const xeus::xjson&);
 
     private:
 
@@ -92,9 +92,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xbutton_style<D>::get_state() const
+    inline xeus::xjson xbutton_style<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(button_color, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(font_weight, state);
@@ -103,7 +103,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xbutton_style<D>::apply_patch(const xjson& patch)
+    inline void xbutton_style<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 
@@ -130,9 +130,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xbutton<D>::get_state() const
+    inline xeus::xjson xbutton<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(description, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(tooltip, state);
@@ -145,7 +145,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xbutton<D>::apply_patch(const xjson& patch)
+    inline void xbutton<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 
@@ -173,7 +173,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xbutton<D>::handle_custom_message(const xjson& content)
+    inline void xbutton<D>::handle_custom_message(const xeus::xjson& content)
     {
         auto it = content.find("event");
         if (it != content.end() && it.value() == "click")

--- a/include/xwidgets/xcheckbox.hpp
+++ b/include/xwidgets/xcheckbox.hpp
@@ -14,7 +14,7 @@
 #include "xboolean.hpp"
 #include "xmaterialize.hpp"
 
-namespace xeus
+namespace xw
 {
     /************************
      * checkbox declaration *
@@ -29,8 +29,8 @@ namespace xeus
         using derived_type = D;
 
         xcheckbox();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(bool, derived_type, indent, true);
 
@@ -53,9 +53,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xcheckbox<D>::get_state() const
+    inline xeus::xjson xcheckbox<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(indent, state);
 
@@ -63,7 +63,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xcheckbox<D>::apply_patch(const xjson& patch)
+    inline void xcheckbox<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xholder.hpp
+++ b/include/xwidgets/xholder.hpp
@@ -6,7 +6,7 @@
 #include "xeus/xguid.hpp"
 #include "xeus/xjson.hpp"
 
-namespace xeus
+namespace xw
 {
     template <class D>
     class xtransport;
@@ -42,7 +42,7 @@ namespace xeus
         void swap(xholder& rhs);
 
         void display() const;
-        xguid id() const;
+        xeus::xguid id() const;
 
         template <class D, bool owning>
         D& get() &;
@@ -70,8 +70,8 @@ namespace xeus
      * to_json and from_json declaration *
      *************************************/
 
-    void to_json(xjson& j, const xholder& o);
-    void from_json(const xjson& j, xholder& o);
+    void to_json(xeus::xjson& j, const xholder& o);
+    void from_json(const xeus::xjson& j, xholder& o);
 
     namespace detail
     {
@@ -87,7 +87,7 @@ namespace xeus
             virtual ~xholder_impl() = default;
 
             virtual void display() const = 0;
-            virtual xguid id() const = 0;
+            virtual xeus::xguid id() const = 0;
 
         protected:
 
@@ -127,7 +127,7 @@ namespace xeus
                 m_value.display();
             }
         
-            virtual xguid id() const override
+            virtual xeus::xguid id() const override
             {
                 return m_value.id();
             }
@@ -170,7 +170,7 @@ namespace xeus
                 p_value->display();
             }
         
-            virtual xguid id() const override
+            virtual xeus::xguid id() const override
             {
                 return p_value->id();
             }
@@ -268,7 +268,7 @@ namespace xeus
         }
     }
 
-    xguid xholder::id() const
+    xeus::xguid xholder::id() const
     {
         if (p_holder != nullptr)
         {
@@ -277,7 +277,7 @@ namespace xeus
         else
         {
             // TODO: throw?
-            return xguid();
+            return xeus::xguid();
         }
     }
 
@@ -325,12 +325,12 @@ namespace xeus
      * to_json and from_json implementation *
      ****************************************/
 
-    inline void to_json(xjson& j, const xholder& o)
+    inline void to_json(xeus::xjson& j, const xholder& o)
     {
         j = "IPY_MODEL_" + guid_to_hex(o.id());
     }
 
-    inline void from_json(const xjson& j, xholder& o)
+    inline void from_json(const xeus::xjson& j, xholder& o)
     {
         /*
         std::string prefixed_guid = j;

--- a/include/xwidgets/xholder_id.hpp
+++ b/include/xwidgets/xholder_id.hpp
@@ -6,7 +6,7 @@
 #include "xholder.hpp"
 #include "xregistry.hpp"  
 
-namespace xeus
+namespace xw
 {
     template <class D>
     xholder make_id_holder(const xtransport<D>& value);
@@ -39,7 +39,7 @@ namespace xeus
                 holder.display();
             }
         
-            virtual xguid id() const override
+            virtual xeus::xguid id() const override
             {
                 return m_id;
             }
@@ -65,7 +65,7 @@ namespace xeus
         private:
 
             xholder_id(const xholder_id&) = default;
-            xguid m_id;
+            xeus::xguid m_id;
         };
     }
 

--- a/include/xwidgets/xhtml.hpp
+++ b/include/xwidgets/xhtml.hpp
@@ -12,7 +12,7 @@
 #include "xmaterialize.hpp"
 #include "xstring.hpp"
 
-namespace xeus
+namespace xw
 {
     /********************
      * html declaration *
@@ -27,8 +27,8 @@ namespace xeus
         using derived_type = D;
 
         xhtml();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
     private:
 
@@ -49,14 +49,14 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xhtml<D>::get_state() const
+    inline xeus::xjson xhtml<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
         return state;
     }
 
     template <class D>
-    inline void xhtml<D>::apply_patch(const xjson& patch)
+    inline void xhtml<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
     }

--- a/include/xwidgets/xlabel.hpp
+++ b/include/xwidgets/xlabel.hpp
@@ -12,7 +12,7 @@
 #include "xmaterialize.hpp"
 #include "xstring.hpp"
 
-namespace xeus
+namespace xw
 {
     /*********************
      * label declaration *
@@ -27,8 +27,8 @@ namespace xeus
         using derived_type = D;
 
         xlabel();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
     private:
 
@@ -49,14 +49,14 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xlabel<D>::get_state() const
+    inline xeus::xjson xlabel<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
         return state;
     }
 
     template <class D>
-    inline void xlabel<D>::apply_patch(const xjson& patch)
+    inline void xlabel<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
     }

--- a/include/xwidgets/xlayout.hpp
+++ b/include/xwidgets/xlayout.hpp
@@ -14,7 +14,7 @@
 #include "xmaterialize.hpp"
 #include "xobject.hpp"
 
-namespace xeus
+namespace xw
 {
     /**********************
      * layout declaration *
@@ -29,8 +29,8 @@ namespace xeus
         using derived_type = D;
 
         xlayout();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(XOPTIONAL(X_CASELESS_STR_ENUM(flex-start, flex-end, center, space-between, space-around, space-evenly, stretch, inherit, inital, unset)), derived_type, align_content);
         XPROPERTY(XOPTIONAL(X_CASELESS_STR_ENUM(flex-start, flex-end, center, baseline, stretch, inherit, inital, unset)), derived_type, align_items);
@@ -63,7 +63,7 @@ namespace xeus
         void set_defaults();
     };
 
-    using layout = xmaterialize<xlayout>;
+    using wlayout = xmaterialize<xlayout>;
 
     /*************************
      * layout implementation *
@@ -77,7 +77,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xlayout<D>::apply_patch(const xjson& patch)
+    inline void xlayout<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 
@@ -106,9 +106,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xlayout<D>::get_state() const
+    inline xeus::xjson xlayout<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(align_content, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(align_items, state);

--- a/include/xwidgets/xlink.hpp
+++ b/include/xwidgets/xlink.hpp
@@ -35,7 +35,7 @@ namespace std
     }
 }
 
-namespace xeus
+namespace xw
 {
     /********************
      * link declaration *

--- a/include/xwidgets/xmaterialize.hpp
+++ b/include/xwidgets/xmaterialize.hpp
@@ -9,7 +9,7 @@
 #ifndef XWIDGETS_MATERIALIZE_HPP
 #define XWIDGETS_MATERIALIZE_HPP
 
-namespace xeus
+namespace xw
 {
 
     /****************************

--- a/include/xwidgets/xnumber.hpp
+++ b/include/xwidgets/xnumber.hpp
@@ -11,7 +11,7 @@
 
 #include "xwidget.hpp"
 
-namespace xeus
+namespace xw
 {
     /****************************
      * base xnumber declaration *
@@ -29,8 +29,8 @@ namespace xeus
         using derived_type = D;
 
         xnumber();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         using value_type = typename xnumber_traits<derived_type>::value_type;
 
@@ -57,9 +57,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xnumber<D>::get_state() const
+    inline xeus::xjson xnumber<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(value, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(min, state);
@@ -69,7 +69,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xnumber<D>::apply_patch(const xjson& patch)
+    inline void xnumber<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xnumeral.hpp
+++ b/include/xwidgets/xnumeral.hpp
@@ -12,7 +12,7 @@
 #include "xmaterialize.hpp"
 #include "xnumber.hpp"
 
-namespace xeus
+namespace xw
 {
     /***********************
      * numeral declaration *
@@ -28,8 +28,8 @@ namespace xeus
         using value_type = typename base_type::value_type;
 
         xnumeral();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(value_type, derived_type, step);
         XPROPERTY(bool, derived_type, disabled);
@@ -61,9 +61,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xnumeral<D>::get_state() const
+    inline xeus::xjson xnumeral<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(step, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(disabled, state);
@@ -73,7 +73,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xnumeral<D>::apply_patch(const xjson& patch)
+    inline void xnumeral<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xobject.hpp
+++ b/include/xwidgets/xobject.hpp
@@ -15,7 +15,7 @@
 #include "xproperty/xobserved.hpp"
 #include "xtransport.hpp"
 
-namespace xeus
+namespace xw
 {
 
     /****************************
@@ -38,8 +38,8 @@ namespace xeus
         using base_type = xtransport<D>;
         using derived_type = D;
 
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(XOPTIONAL(std::string), derived_type, _model_module, "jupyter-js-widgets");
         XPROPERTY(XOPTIONAL(std::string), derived_type, _model_module_version, "~2.1.4");
@@ -65,7 +65,7 @@ namespace xeus
     patch[#name] = this->name();
 
     template <class D>
-    inline void xobject<D>::apply_patch(const xjson& patch)
+    inline void xobject<D>::apply_patch(const xeus::xjson& patch)
     {
         XOBJECT_SET_PROPERTY_FROM_PATCH(_model_module, patch);
         XOBJECT_SET_PROPERTY_FROM_PATCH(_model_module_version, patch);
@@ -76,9 +76,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xobject<D>::get_state() const
+    inline xeus::xjson xobject<D>::get_state() const
     {
-        xjson state;
+        xeus::xjson state;
         XOBJECT_SET_PATCH_FROM_PROPERTY(_model_module, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(_model_module_version, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(_model_name, state);

--- a/include/xwidgets/xpassword.hpp
+++ b/include/xwidgets/xpassword.hpp
@@ -12,7 +12,7 @@
 #include "xpassword.hpp"
 #include "xstring.hpp"
 
-namespace xeus
+namespace xw
 {
     /************************
      * password declaration *
@@ -27,8 +27,8 @@ namespace xeus
         using derived_type = D;
 
         xpassword();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(bool, derived_type, disabled);
 
@@ -51,9 +51,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xpassword<D>::get_state() const
+    inline xeus::xjson xpassword<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(disabled, state);
 
@@ -61,7 +61,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xpassword<D>::apply_patch(const xjson& patch)
+    inline void xpassword<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xplay.hpp
+++ b/include/xwidgets/xplay.hpp
@@ -12,7 +12,7 @@
 #include "xmaterialize.hpp"
 #include "xnumber.hpp"
 
-namespace xeus
+namespace xw
 {
     /********************
      * play declaration *
@@ -28,8 +28,8 @@ namespace xeus
         using value_type = typename base_type::value_type;
 
         xplay();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(value_type, derived_type, interval, value_type(100));
         XPROPERTY(value_type, derived_type, step, value_type(1));
@@ -63,9 +63,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xplay<D>::get_state() const
+    inline xeus::xjson xplay<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(interval, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(step, state);
@@ -78,7 +78,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xplay<D>::apply_patch(const xjson& patch)
+    inline void xplay<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xprogress.hpp
+++ b/include/xwidgets/xprogress.hpp
@@ -13,7 +13,7 @@
 #include "xnumber.hpp"
 #include "xstyle.hpp"
 
-namespace xeus
+namespace xw
 {
     /******************************
      * progress_style declaration *
@@ -28,8 +28,8 @@ namespace xeus
         using derived_type = D;
 
         xprogress_style();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, description_width);
         XPROPERTY(XOPTIONAL(std::string), derived_type, bar_color);
@@ -55,12 +55,12 @@ namespace xeus
         using value_type = typename base_type::value_type;
 
         xprogress();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(X_CASELESS_STR_ENUM(horizontal, vertical), derived_type, orientation, "horizontal");
         XPROPERTY(X_CASELESS_STR_ENUM(success, info, warning, danger, ), derived_type, bar_style);
-        XPROPERTY(::xeus::progress_style, derived_type, style);
+        XPROPERTY(::xw::progress_style, derived_type, style);
 
     private:
 
@@ -88,9 +88,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xprogress_style<D>::get_state() const
+    inline xeus::xjson xprogress_style<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(bar_color, state);
 
@@ -98,7 +98,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xprogress_style<D>::apply_patch(const xjson& patch)
+    inline void xprogress_style<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
         XOBJECT_SET_PROPERTY_FROM_PATCH(bar_color, patch);
@@ -123,9 +123,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xprogress<D>::get_state() const
+    inline xeus::xjson xprogress<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(orientation, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(bar_style, state);
@@ -135,7 +135,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xprogress<D>::apply_patch(const xjson& patch)
+    inline void xprogress<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xregistry.hpp
+++ b/include/xwidgets/xregistry.hpp
@@ -7,7 +7,7 @@
 #include "xholder.hpp" 
 #include "xtransport.hpp"
 
-namespace xeus
+namespace xw
 {
     /*************************
      * xregistry declaration *
@@ -22,9 +22,9 @@ namespace xeus
         template <class D>
         void register_weak(xtransport<D>* ptr);
 
-        void unregister(xguid id);
+        void unregister(xeus::xguid id);
 
-        typename storage_type::mapped_type& find(xguid id);
+        typename storage_type::mapped_type& find(xeus::xguid id);
 
     private:
 
@@ -47,14 +47,14 @@ namespace xeus
         m_storage[xeus::guid_to_hex(ptr->id())] = make_weak_holder(ptr);
     }
 
-    void xregistry::unregister(xguid id)
+    void xregistry::unregister(xeus::xguid id)
     {
-        m_storage.erase(guid_to_hex(id));
+        m_storage.erase(xeus::guid_to_hex(id));
     }
 
-    auto xregistry::find(xguid id) -> typename storage_type::mapped_type&
+    auto xregistry::find(xeus::xguid id) -> typename storage_type::mapped_type&
     {
-        auto it = m_storage.find(guid_to_hex(id));
+        auto it = m_storage.find(xeus::guid_to_hex(id));
         if (it == m_storage.end())
         {
             throw std::runtime_error("Could not find specified id in widgets registry");

--- a/include/xwidgets/xslider.hpp
+++ b/include/xwidgets/xslider.hpp
@@ -13,7 +13,7 @@
 #include "xnumber.hpp"
 #include "xstyle.hpp"
 
-namespace xeus
+namespace xw
 {
     /****************************
      * slider_style declaration *
@@ -28,8 +28,8 @@ namespace xeus
         using derived_type = D;
 
         xslider_style();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, description_width);
         XPROPERTY(XOPTIONAL(std::string), derived_type, handle_color);
@@ -55,8 +55,8 @@ namespace xeus
         using value_type = typename base_type::value_type;
 
         xslider();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(value_type, derived_type, step, value_type(1));
         XPROPERTY(X_CASELESS_STR_ENUM(horizontal, vertical), derived_type, orientation, "horizontal");
@@ -64,7 +64,7 @@ namespace xeus
         XPROPERTY(std::string, derived_type, readout_format, ".2f");
         XPROPERTY(bool, derived_type, continuous_update, true);
         XPROPERTY(bool, derived_type, disabled);
-        XPROPERTY(::xeus::slider_style, derived_type, style);
+        XPROPERTY(::xw::slider_style, derived_type, style);
 
     private:
 
@@ -92,9 +92,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xslider_style<D>::get_state() const
+    inline xeus::xjson xslider_style<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(handle_color, state);
 
@@ -102,7 +102,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xslider_style<D>::apply_patch(const xjson& patch)
+    inline void xslider_style<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
         XOBJECT_SET_PROPERTY_FROM_PATCH(handle_color, patch);
@@ -127,9 +127,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xslider<D>::get_state() const
+    inline xeus::xjson xslider<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(step, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(orientation, state);
@@ -143,7 +143,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xslider<D>::apply_patch(const xjson& patch)
+    inline void xslider<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xstring.hpp
+++ b/include/xwidgets/xstring.hpp
@@ -13,7 +13,7 @@
 
 #include "xwidget.hpp"
 
-namespace xeus
+namespace xw
 {
     /****************************
      * base xstring declaration *
@@ -28,8 +28,8 @@ namespace xeus
         using derived_type = D;
 
         xstring();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, description);
         XPROPERTY(std::string, derived_type, value);
@@ -52,9 +52,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xstring<D>::get_state() const
+    inline xeus::xjson xstring<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(value, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(placeholder, state);
@@ -63,7 +63,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xstring<D>::apply_patch(const xjson& patch)
+    inline void xstring<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xstyle.hpp
+++ b/include/xwidgets/xstyle.hpp
@@ -13,7 +13,7 @@
 
 #include "xobject.hpp"
 
-namespace xeus
+namespace xw
 {
     /***************************
      * base xstyle declaration *
@@ -28,8 +28,8 @@ namespace xeus
         using derived_type = D;
 
         xstyle();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
     private:
 
@@ -48,15 +48,15 @@ namespace xeus
     }
 
     template <class D>
-    inline void xstyle<D>::apply_patch(const xjson& patch)
+    inline void xstyle<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
     }
 
     template <class D>
-    inline xjson xstyle<D>::get_state() const
+    inline xeus::xjson xstyle<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
         return state;
     }
 

--- a/include/xwidgets/xtext.hpp
+++ b/include/xwidgets/xtext.hpp
@@ -12,7 +12,7 @@
 #include "xmaterialize.hpp"
 #include "xstring.hpp"
 
-namespace xeus
+namespace xw
 {
     /********************
      * text declaration *
@@ -29,15 +29,15 @@ namespace xeus
         using derived_type = D;
 
         xtext();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         void on_submit(submit_callback_type);
 
         XPROPERTY(bool, derived_type, disabled);
         XPROPERTY(bool, derived_type, continuous_update, true);
 
-        void handle_custom_message(const xjson&);
+        void handle_custom_message(const xeus::xjson&);
 
     private:
 
@@ -60,9 +60,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xtext<D>::get_state() const
+    inline xeus::xjson xtext<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(disabled, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(continuous_update, state);
@@ -71,7 +71,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xtext<D>::apply_patch(const xjson& patch)
+    inline void xtext<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 
@@ -93,7 +93,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xtext<D>::handle_custom_message(const xjson& content)
+    inline void xtext<D>::handle_custom_message(const xeus::xjson& content)
     {
         auto it = content.find("event");
         if (it != content.end() && it.value() == "submit")

--- a/include/xwidgets/xtextarea.hpp
+++ b/include/xwidgets/xtextarea.hpp
@@ -12,7 +12,7 @@
 #include "xmaterialize.hpp"
 #include "xstring.hpp"
 
-namespace xeus
+namespace xw
 {
     /************************
      * textarea declaration *
@@ -27,8 +27,8 @@ namespace xeus
         using derived_type = D;
 
         xtextarea();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(XOPTIONAL(int), derived_type, rows);
         XPROPERTY(bool, derived_type, disabled);
@@ -53,9 +53,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xtextarea<D>::get_state() const
+    inline xeus::xjson xtextarea<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(rows, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(disabled, state);
@@ -65,7 +65,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xtextarea<D>::apply_patch(const xjson& patch)
+    inline void xtextarea<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xtogglebutton.hpp
+++ b/include/xwidgets/xtogglebutton.hpp
@@ -14,7 +14,7 @@
 #include "xboolean.hpp"
 #include "xmaterialize.hpp"
 
-namespace xeus
+namespace xw
 {
     /****************************
      * togglebutton declaration *
@@ -29,8 +29,8 @@ namespace xeus
         using derived_type = D;
 
         xtogglebutton();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, tooltip);
         XPROPERTY(std::string, derived_type, icon);
@@ -55,9 +55,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xtogglebutton<D>::get_state() const
+    inline xeus::xjson xtogglebutton<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(tooltip, state);
         XOBJECT_SET_PATCH_FROM_PROPERTY(icon, state);
@@ -67,7 +67,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xtogglebutton<D>::apply_patch(const xjson& patch)
+    inline void xtogglebutton<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xvalid.hpp
+++ b/include/xwidgets/xvalid.hpp
@@ -14,7 +14,7 @@
 #include "xboolean.hpp"
 #include "xmaterialize.hpp"
 
-namespace xeus
+namespace xw
 {
     /*********************
      * valid declaration *
@@ -29,8 +29,8 @@ namespace xeus
         using derived_type = D;
 
         xvalid();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, readout, "Invalid");
 
@@ -53,9 +53,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xvalid<D>::get_state() const
+    inline xeus::xjson xvalid<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(readout, state);
 
@@ -63,7 +63,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xvalid<D>::apply_patch(const xjson& patch)
+    inline void xvalid<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 

--- a/include/xwidgets/xwidget.hpp
+++ b/include/xwidgets/xwidget.hpp
@@ -14,7 +14,7 @@
 #include "xlayout.hpp"
 #include "xobject.hpp"
 
-namespace xeus
+namespace xw
 {
     /******************************
      * base xwidgets declarations *
@@ -29,10 +29,10 @@ namespace xeus
         using derived_type = D;
 
         xwidget();
-        xjson get_state() const;
-        void apply_patch(const xjson& patch);
+        xeus::xjson get_state() const;
+        void apply_patch(const xeus::xjson& patch);
 
-        XPROPERTY(::xeus::layout, derived_type, layout);
+        XPROPERTY(wlayout, derived_type, layout);
 
     private:
 
@@ -51,7 +51,7 @@ namespace xeus
     }
 
     template <class D>
-    inline void xwidget<D>::apply_patch(const xjson& patch)
+    inline void xwidget<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
 
@@ -59,9 +59,9 @@ namespace xeus
     }
 
     template <class D>
-    inline xjson xwidget<D>::get_state() const
+    inline xeus::xjson xwidget<D>::get_state() const
     {
-        xjson state = base_type::get_state();
+        xeus::xjson state = base_type::get_state();
 
         XOBJECT_SET_PATCH_FROM_PROPERTY(layout, state);
 

--- a/test/test_xwidgets.cpp
+++ b/test/test_xwidgets.cpp
@@ -24,7 +24,7 @@
 #include "xwidgets/xtogglebutton.hpp"
 #include "xwidgets/xvalid.hpp"
 
-namespace xeus
+namespace xw
 {
     TEST(xwidgets, hbox)
     {
@@ -85,7 +85,7 @@ namespace xeus
 
     TEST(xwidgets, layout)
     {
-        layout l;
+        wlayout l;
         l.bottom = "bottom";
         ASSERT_EQ("bottom", l.bottom());
     }


### PR DESCRIPTION
@SylvainCorlay I had to remane ``layout`` (the type) into ``wlayout``, otherwise theire is a conflict in the ``xwidget`` class between the ``layout`` type and the ``layout`` member.