### PR TITLE
Introduction of xgenerator

### DIFF
--- a/include/xwidgets/xboolean.hpp
+++ b/include/xwidgets/xboolean.hpp
@@ -26,7 +26,6 @@ namespace xw
         using base_type = xwidget<D>;
         using derived_type = D;
 
-        xboolean();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -34,6 +33,10 @@ namespace xw
 
         XPROPERTY(bool, derived_type, value);
         XPROPERTY(bool, derived_type, disabled);
+
+    protected:
+
+        xboolean();
 
     private:
 
@@ -43,13 +46,6 @@ namespace xw
     /***************************
      * xboolean implementation *
      ***************************/
-
-    template <class D>
-    inline xboolean<D>::xboolean()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xboolean<D>::get_state() const
@@ -69,6 +65,13 @@ namespace xw
 
         XOBJECT_SET_PROPERTY_FROM_PATCH(value, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(disabled, patch)
+    }
+
+    template <class D>
+    inline xboolean<D>::xboolean()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xbox.hpp
+++ b/include/xwidgets/xbox.hpp
@@ -30,7 +30,6 @@ namespace xw
         using derived_type = D;
         using children_list_type = xbox_children_list_type;
 
-        xbox();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -42,6 +41,10 @@ namespace xw
 
         template <class T>
         void add(xtransport<T>&& w);
+
+    protected:
+
+        xbox();
 
     private:
 
@@ -60,6 +63,8 @@ namespace xw
         using base_type = xbox<D>;
         using derived_type = D;
 
+    protected:
+
         xhbox();
 
     private:
@@ -68,6 +73,8 @@ namespace xw
     };
 
     using hbox = xmaterialize<xhbox>;
+
+    using hbox_generator = xgenerator<xhbox>;
 
     /********************
      * vbox declaration *
@@ -81,6 +88,8 @@ namespace xw
         using base_type = xbox<D>;
         using derived_type = D;
 
+    protected:
+
         xvbox();
 
     private:
@@ -90,16 +99,11 @@ namespace xw
 
     using vbox = xmaterialize<xvbox>;
 
+    using vbox_generator = xgenerator<xvbox>;
+
     /***********************
      * xbox implementation *
      ***********************/
-
-    template <class D>
-    inline xbox<D>::xbox()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xbox<D>::get_state() const
@@ -139,6 +143,13 @@ namespace xw
         xeus::xjson state;
         XOBJECT_SET_PATCH_FROM_PROPERTY(children, state);
         this->send_patch(std::move(state));
+    }
+
+    template <class D>
+    inline xbox<D>::xbox()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xbutton.hpp
+++ b/include/xwidgets/xbutton.hpp
@@ -27,12 +27,15 @@ namespace xw
         using base_type = xstyle<D>;
         using derived_type = D;
 
-        xbutton_style();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(xtl::xoptional<std::string>, derived_type, button_color);
         XPROPERTY(std::string, derived_type, font_weight);
+
+    protected:
+
+        xbutton_style();
 
     private:
 
@@ -40,6 +43,8 @@ namespace xw
     };
 
     using button_style = xmaterialize<xbutton_style>;
+
+    using button_style_generator = xgenerator<xbutton_style>;
 
     /**********************
      * button declaration *
@@ -55,7 +60,6 @@ namespace xw
         using base_type = xwidget<D>;
         using derived_type = D;
 
-        xbutton();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -71,6 +75,10 @@ namespace xw
 
         void handle_custom_message(const xeus::xjson&);
 
+    protected:
+
+        xbutton();
+
     private:
 
         void set_defaults();
@@ -80,16 +88,11 @@ namespace xw
 
     using button = xmaterialize<xbutton>;
 
+    using button_generator = xgenerator<xbutton>;
+
     /********************************
      * xbutton_style implementation *
      ********************************/
-
-    template <class D>
-    inline xbutton_style<D>::xbutton_style()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xbutton_style<D>::get_state() const
@@ -112,6 +115,13 @@ namespace xw
     }
 
     template <class D>
+    inline xbutton_style<D>::xbutton_style()
+        : base_type()
+    {
+        set_defaults();
+    }
+
+    template <class D>
     inline void xbutton_style<D>::set_defaults()
     {
         this->_model_module() = "@jupyter-widgets/controls";
@@ -121,13 +131,6 @@ namespace xw
     /**************************
      * xbutton implementation *
      **************************/
-
-    template <class D>
-    inline xbutton<D>::xbutton()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xbutton<D>::get_state() const
@@ -161,6 +164,13 @@ namespace xw
     inline void xbutton<D>::on_click(click_callback_type cb)
     {
         m_click_callbacks.emplace_back(std::move(cb));
+    }
+
+    template <class D>
+    inline xbutton<D>::xbutton()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xcheckbox.hpp
+++ b/include/xwidgets/xcheckbox.hpp
@@ -28,11 +28,14 @@ namespace xw
         using base_type = xboolean<D>;
         using derived_type = D;
 
-        xcheckbox();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(bool, derived_type, indent, true);
+
+    protected:
+
+        xcheckbox();
 
     private:
 
@@ -41,16 +44,11 @@ namespace xw
 
     using checkbox = xmaterialize<xcheckbox>;
 
+    using checkbox_generator = xgenerator<xcheckbox>;
+
     /****************************
      * xcheckbox implementation *
      ****************************/
-
-    template <class D>
-    inline xcheckbox<D>::xcheckbox()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xcheckbox<D>::get_state() const
@@ -68,6 +66,13 @@ namespace xw
         base_type::apply_patch(patch);
 
         XOBJECT_SET_PROPERTY_FROM_PATCH(indent, patch)
+    }
+
+    template <class D>
+    inline xcheckbox<D>::xcheckbox()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xhtml.hpp
+++ b/include/xwidgets/xhtml.hpp
@@ -26,9 +26,12 @@ namespace xw
         using base_type = xstring<D>;
         using derived_type = D;
 
-        xhtml();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
+
+    protected:
+
+        xhtml();
 
     private:
 
@@ -37,16 +40,11 @@ namespace xw
 
     using html = xmaterialize<xhtml>;
 
+    using html_generator = xgenerator<xhtml>;
+
     /************************
      * xhtml implementation *
      ************************/
-
-    template <class D>
-    inline xhtml<D>::xhtml()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xhtml<D>::get_state() const
@@ -59,6 +57,13 @@ namespace xw
     inline void xhtml<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
+    }
+
+    template <class D>
+    inline xhtml<D>::xhtml()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xlabel.hpp
+++ b/include/xwidgets/xlabel.hpp
@@ -26,9 +26,12 @@ namespace xw
         using base_type = xstring<D>;
         using derived_type = D;
 
-        xlabel();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
+
+    protected:
+
+        xlabel();
 
     private:
 
@@ -37,16 +40,11 @@ namespace xw
 
     using label = xmaterialize<xlabel>;
 
+    using label_generator = xgenerator<xlabel>;
+
     /*************************
      * xlabel implementation *
      ************************/
-
-    template <class D>
-    inline xlabel<D>::xlabel()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xlabel<D>::get_state() const
@@ -59,6 +57,13 @@ namespace xw
     inline void xlabel<D>::apply_patch(const xeus::xjson& patch)
     {
         base_type::apply_patch(patch);
+    }
+
+    template <class D>
+    inline xlabel<D>::xlabel()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xlayout.hpp
+++ b/include/xwidgets/xlayout.hpp
@@ -28,7 +28,6 @@ namespace xw
         using base_type = xobject<D>;
         using derived_type = D;
 
-        xlayout();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -58,6 +57,10 @@ namespace xw
         XPROPERTY(xtl::xoptional<std::string>, derived_type, visibility);
         XPROPERTY(xtl::xoptional<std::string>, derived_type, width);
 
+    protected:
+
+        xlayout();
+
     private:
 
         void set_defaults();
@@ -65,16 +68,11 @@ namespace xw
 
     using layout = xmaterialize<xlayout>;
 
+    using layout_generator = xgenerator<xlayout>;
+
     /*************************
      * layout implementation *
      *************************/
-
-    template <class D>
-    inline xlayout<D>::xlayout()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline void xlayout<D>::apply_patch(const xeus::xjson& patch)
@@ -136,6 +134,13 @@ namespace xw
         XOBJECT_SET_PATCH_FROM_PROPERTY(width, state);
 
         return state;
+    }
+
+    template <class D>
+    inline xlayout<D>::xlayout()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xlink.hpp
+++ b/include/xwidgets/xlink.hpp
@@ -48,17 +48,20 @@ namespace xw
 
         using base_type = xobject<D>;
         using derived_type = D;
-
         using pair_type = xlink_pair_type;
 
-        xlink();
-        template <class S, class T>
-        xlink(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn);
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(pair_type, derived_type, source);
         XPROPERTY(pair_type, derived_type, target);
+
+    protected:
+
+        xlink();
+
+        template <class S, class T>
+        xlink(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn);
 
     private:
 
@@ -67,28 +70,11 @@ namespace xw
 
     using link = xmaterialize<xlink>;
 
+    using link_generator = xgenerator<xlink>;
+
     /************************
      * xlink implementation *
      ************************/
-
-    template <class D>
-    inline xlink<D>::xlink()
-        : base_type()
-    {
-        set_defaults();
-    }
-
-    template <class D>
-    template <class S, class T>
-    inline xlink<D>::xlink(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn)
-        : base_type()
-    {
-        set_defaults();
-        this->source().first = s;
-        this->source().second = sn;
-        this->target().first = t;
-        this->target().second = tn;
-    }
 
     template <class D>
     inline xeus::xjson xlink<D>::get_state() const
@@ -108,6 +94,25 @@ namespace xw
 
         XOBJECT_SET_PROPERTY_FROM_PATCH(source, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(target, patch)
+    }
+
+    template <class D>
+    inline xlink<D>::xlink()
+        : base_type()
+    {
+        set_defaults();
+    }
+
+    template <class D>
+    template <class S, class T>
+    inline xlink<D>::xlink(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn)
+        : base_type()
+    {
+        set_defaults();
+        this->source().first = s;
+        this->source().second = sn;
+        this->target().first = t;
+        this->target().second = tn;
     }
 
     template <class D>

--- a/include/xwidgets/xmaterialize.hpp
+++ b/include/xwidgets/xmaterialize.hpp
@@ -11,14 +11,6 @@
 
 namespace xw
 {
-
-    template <class T, class... Args>
-    T make_widget(Args&&... args)
-    {
-        typename T::base_type tmp(std::forward<Args>(args)...);
-        return std::move(tmp.derived_cast());
-    }
-
     /****************************
      * xmaterialize declaration *
      ****************************/
@@ -42,8 +34,23 @@ namespace xw
 
         xmaterialize(xmaterialize&&) = default;
         xmaterialize& operator=(xmaterialize&&) = default;
+    };
 
-        const xmaterialize& finalize() const;
+    /**************************
+     * xgenerator declaration *
+     **************************/
+
+    // CRTP and mixin
+
+    template <template <class> class B, class... P>
+    class xgenerator final : public B<xgenerator<B, P...>>
+    {
+    public:
+
+        using self_type = xgenerator<B, P...>;
+        using base_type = B<self_type>;
+
+        xmaterialize<B, P...> finalize() &&;
     };
 
     /*******************************
@@ -83,10 +90,14 @@ namespace xw
         return *this;
     }
 
+    /*****************************
+     * xgenerator implementation *
+     *****************************/
+
     template <template <class> class B, class... P>
-    inline const xmaterialize<B, P...>& xmaterialize<B, P...>::finalize() const
+    inline xmaterialize<B, P...> xgenerator<B, P...>::finalize() &&
     {
-        return *this;
+        return reinterpret_cast<typename xmaterialize<B, P...>::base_type&&>(*this);
     }
 }
 

--- a/include/xwidgets/xnumber.hpp
+++ b/include/xwidgets/xnumber.hpp
@@ -28,7 +28,6 @@ namespace xw
         using base_type = xwidget<D>;
         using derived_type = D;
 
-        xnumber();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -40,6 +39,10 @@ namespace xw
         XPROPERTY(value_type, derived_type, min);
         XPROPERTY(value_type, derived_type, max, value_type(100));
 
+    protected:
+
+        xnumber();
+
     private:
 
         void set_defaults();
@@ -48,13 +51,6 @@ namespace xw
     /**************************
      * xnumber implementation *
      **************************/
-
-    template <class D>
-    inline xnumber<D>::xnumber()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xnumber<D>::get_state() const
@@ -76,6 +72,13 @@ namespace xw
         XOBJECT_SET_PROPERTY_FROM_PATCH(value, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(min, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(max, patch)
+    }
+
+    template <class D>
+    inline xnumber<D>::xnumber()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xnumeral.hpp
+++ b/include/xwidgets/xnumeral.hpp
@@ -27,13 +27,16 @@ namespace xw
         using derived_type = D;
         using value_type = typename base_type::value_type;
 
-        xnumeral();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(value_type, derived_type, step);
         XPROPERTY(bool, derived_type, disabled);
         XPROPERTY(bool, derived_type, continuous_update);
+
+    protected:
+
+        xnumeral();
 
     private:
 
@@ -44,6 +47,9 @@ namespace xw
     using numeral = xmaterialize<xnumeral, T>;
 
     template <class T>
+    using numeral_generator = xgenerator<xnumeral, T>;
+
+    template <class T>
     struct xnumber_traits<numeral<T>>
     {
         using value_type = T;
@@ -52,13 +58,6 @@ namespace xw
     /***************************
      * xnumeral implementation *
      ***************************/
-
-    template <class D>
-    inline xnumeral<D>::xnumeral()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xnumeral<D>::get_state() const
@@ -80,6 +79,13 @@ namespace xw
         XOBJECT_SET_PROPERTY_FROM_PATCH(step, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(disabled, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(continuous_update, patch)
+    }
+
+    template <class D>
+    inline xnumeral<D>::xnumeral()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xpassword.hpp
+++ b/include/xwidgets/xpassword.hpp
@@ -26,11 +26,14 @@ namespace xw
         using base_type = xstring<D>;
         using derived_type = D;
 
-        xpassword();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(bool, derived_type, disabled);
+
+    protected:
+
+        xpassword();
 
     private:
 
@@ -39,16 +42,11 @@ namespace xw
 
     using password = xmaterialize<xpassword>;
 
+    using password_generator = xgenerator<xpassword>;
+
     /****************************
      * xpassword implementation *
      ****************************/
-
-    template <class D>
-    inline xpassword<D>::xpassword()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xpassword<D>::get_state() const
@@ -66,6 +64,13 @@ namespace xw
         base_type::apply_patch(patch);
 
         XOBJECT_SET_PROPERTY_FROM_PATCH(disabled, patch)
+    }
+
+    template <class D>
+    inline xpassword<D>::xpassword()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xplay.hpp
+++ b/include/xwidgets/xplay.hpp
@@ -27,7 +27,6 @@ namespace xw
         using derived_type = D;
         using value_type = typename base_type::value_type;
 
-        xplay();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -38,12 +37,18 @@ namespace xw
         XPROPERTY(bool, derived_type, _repeat);
         XPROPERTY(bool, derived_type, show_repeat, true);
 
+    protected:
+
+        xplay();
+
     private:
 
         void set_defaults();
     };
 
     using play = xmaterialize<xplay>;
+
+    using play_generator = xgenerator<xplay>;
 
     template <>
     struct xnumber_traits<play>
@@ -54,13 +59,6 @@ namespace xw
     /************************
      * xplay implementation *
      ************************/
-
-    template <class D>
-    inline xplay<D>::xplay()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xplay<D>::get_state() const
@@ -88,6 +86,13 @@ namespace xw
         XOBJECT_SET_PROPERTY_FROM_PATCH(_playing, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(_repeat, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(show_repeat, patch)
+    }
+
+    template <class D>
+    inline xplay<D>::xplay()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xprogress.hpp
+++ b/include/xwidgets/xprogress.hpp
@@ -27,12 +27,15 @@ namespace xw
         using base_type = xstyle<D>;
         using derived_type = D;
 
-        xprogress_style();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, description_width);
         XPROPERTY(xtl::xoptional<std::string>, derived_type, bar_color);
+
+    protected:
+
+        xprogress_style();
 
     private:
 
@@ -40,6 +43,8 @@ namespace xw
     };
 
     using progress_style = xmaterialize<xprogress_style>;
+
+    using progress_style_generator = xgenerator<xprogress_style>;
 
     /***********************
      * progress declaration *
@@ -54,13 +59,16 @@ namespace xw
         using derived_type = D;
         using value_type = typename base_type::value_type;
 
-        xprogress();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(X_CASELESS_STR_ENUM(horizontal, vertical), derived_type, orientation, "horizontal");
         XPROPERTY(X_CASELESS_STR_ENUM(success, info, warning, danger, ), derived_type, bar_style);
         XPROPERTY(::xw::progress_style, derived_type, style);
+
+    protected:
+
+        xprogress();
 
     private:
 
@@ -71,6 +79,9 @@ namespace xw
     using progress = xmaterialize<xprogress, T>;
 
     template <class T>
+    using progress_generator = xgenerator<xprogress, T>;
+
+    template <class T>
     struct xnumber_traits<progress<T>>
     {
         using value_type = T;
@@ -79,13 +90,6 @@ namespace xw
     /**********************************
      * xprogress_style implementation *
      **********************************/
-
-    template <class D>
-    inline xprogress_style<D>::xprogress_style()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xprogress_style<D>::get_state() const
@@ -105,6 +109,13 @@ namespace xw
     }
 
     template <class D>
+    inline xprogress_style<D>::xprogress_style()
+        : base_type()
+    {
+        set_defaults();
+    }
+
+    template <class D>
     inline void xprogress_style<D>::set_defaults()
     {
         this->_model_module() = "@jupyter-widgets/controls";
@@ -114,13 +125,6 @@ namespace xw
     /****************************
      * xprogress implementation *
      ****************************/
-
-    template <class D>
-    inline xprogress<D>::xprogress()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xprogress<D>::get_state() const
@@ -142,6 +146,13 @@ namespace xw
         XOBJECT_SET_PROPERTY_FROM_PATCH(orientation, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(bar_style, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(style, patch)
+    }
+
+    template <class D>
+    inline xprogress<D>::xprogress()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xslider.hpp
+++ b/include/xwidgets/xslider.hpp
@@ -27,12 +27,15 @@ namespace xw
         using base_type = xstyle<D>;
         using derived_type = D;
 
-        xslider_style();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, description_width);
         XPROPERTY(xtl::xoptional<std::string>, derived_type, handle_color);
+
+    protected:
+
+        xslider_style();
 
     private:
 
@@ -40,6 +43,8 @@ namespace xw
     };
 
     using slider_style = xmaterialize<xslider_style>;
+
+    using slider_style_generator = xgenerator<xslider_style>;
 
     /**********************
      * slider declaration *
@@ -54,7 +59,6 @@ namespace xw
         using derived_type = D;
         using value_type = typename base_type::value_type;
 
-        xslider();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -66,6 +70,10 @@ namespace xw
         XPROPERTY(bool, derived_type, disabled);
         XPROPERTY(::xw::slider_style, derived_type, style);
 
+    protected:
+
+        xslider();
+
     private:
 
         void set_defaults();
@@ -75,7 +83,16 @@ namespace xw
     using slider = xmaterialize<xslider, T>;
 
     template <class T>
+    using slider_generator = xgenerator<xslider, T>;
+
+    template <class T>
     struct xnumber_traits<slider<T>>
+    {
+        using value_type = T;
+    };
+
+    template <class T>
+    struct xnumber_traits<slider_generator<T>>
     {
         using value_type = T;
     };
@@ -83,13 +100,6 @@ namespace xw
     /********************************
      * xslider_style implementation *
      ********************************/
-
-    template <class D>
-    inline xslider_style<D>::xslider_style()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xslider_style<D>::get_state() const
@@ -109,6 +119,13 @@ namespace xw
     }
 
     template <class D>
+    inline xslider_style<D>::xslider_style()
+        : base_type()
+    {
+        set_defaults();
+    }
+
+    template <class D>
     inline void xslider_style<D>::set_defaults()
     {
         this->_model_module() = "@jupyter-widgets/controls";
@@ -118,13 +135,6 @@ namespace xw
     /**************************
      * xslider implementation *
      **************************/
-
-    template <class D>
-    inline xslider<D>::xslider()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xslider<D>::get_state() const
@@ -154,6 +164,13 @@ namespace xw
         XOBJECT_SET_PROPERTY_FROM_PATCH(continuous_update, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(disabled, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(style, patch)
+    }
+
+    template <class D>
+    inline xslider<D>::xslider()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xstring.hpp
+++ b/include/xwidgets/xstring.hpp
@@ -27,13 +27,16 @@ namespace xw
         using base_type = xwidget<D>;
         using derived_type = D;
 
-        xstring();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, description);
         XPROPERTY(std::string, derived_type, value);
         XPROPERTY(std::string, derived_type, placeholder, "\u00A0");
+
+    protected:
+
+        xstring();
 
     private:
 
@@ -43,13 +46,6 @@ namespace xw
     /**************************
      * xstring implementation *
      **************************/
-
-    template <class D>
-    inline xstring<D>::xstring()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xstring<D>::get_state() const
@@ -69,6 +65,13 @@ namespace xw
 
         XOBJECT_SET_PROPERTY_FROM_PATCH(value, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(placeholder, patch)
+    }
+
+    template <class D>
+    inline xstring<D>::xstring()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xstyle.hpp
+++ b/include/xwidgets/xstyle.hpp
@@ -27,9 +27,12 @@ namespace xw
         using base_type = xobject<D>;
         using derived_type = D;
 
-        xstyle();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
+
+    protected:
+
+        xstyle();
 
     private:
 
@@ -39,13 +42,6 @@ namespace xw
     /******************************
      * base xstyle implementation *
      ******************************/
-
-    template <class D>
-    inline xstyle<D>::xstyle()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline void xstyle<D>::apply_patch(const xeus::xjson& patch)
@@ -58,6 +54,13 @@ namespace xw
     {
         xeus::xjson state = base_type::get_state();
         return state;
+    }
+
+    template <class D>
+    inline xstyle<D>::xstyle()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xtext.hpp
+++ b/include/xwidgets/xtext.hpp
@@ -28,7 +28,6 @@ namespace xw
         using base_type = xstring<D>;
         using derived_type = D;
 
-        xtext();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -39,6 +38,10 @@ namespace xw
 
         void handle_custom_message(const xeus::xjson&);
 
+    protected:
+
+        xtext();
+
     private:
 
         void set_defaults();
@@ -48,16 +51,11 @@ namespace xw
 
     using text = xmaterialize<xtext>;
 
+    using text_generator = xgenerator<xtext>;
+
     /************************
      * xtext implementation *
      ************************/
-
-    template <class D>
-    inline xtext<D>::xtext()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xtext<D>::get_state() const
@@ -83,6 +81,13 @@ namespace xw
     inline void xtext<D>::on_submit(submit_callback_type cb)
     {
         m_submit_callbacks.emplace_back(std::move(cb));
+    }
+
+    template <class D>
+    inline xtext<D>::xtext()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xtextarea.hpp
+++ b/include/xwidgets/xtextarea.hpp
@@ -26,7 +26,6 @@ namespace xw
         using base_type = xstring<D>;
         using derived_type = D;
 
-        xtextarea();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -34,23 +33,21 @@ namespace xw
         XPROPERTY(bool, derived_type, disabled);
         XPROPERTY(bool, derived_type, continuous_update, true);
 
+    protected:
+
+        xtextarea();
+
     private:
 
         void set_defaults();
     };
 
     using textarea = xmaterialize<xtextarea>;
+    using textarea_generator = xgenerator<xtextarea>;
 
     /****************************
      * xtextarea implementation *
      ****************************/
-
-    template <class D>
-    inline xtextarea<D>::xtextarea()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xtextarea<D>::get_state() const
@@ -72,6 +69,13 @@ namespace xw
         XOBJECT_SET_PROPERTY_FROM_PATCH(rows, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(disabled, patch)
         XOBJECT_SET_PROPERTY_FROM_PATCH(continuous_update, patch)
+    }
+
+    template <class D>
+    inline xtextarea<D>::xtextarea()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xtogglebutton.hpp
+++ b/include/xwidgets/xtogglebutton.hpp
@@ -28,7 +28,6 @@ namespace xw
         using base_type = xboolean<D>;
         using derived_type = D;
 
-        xtogglebutton();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
@@ -36,12 +35,18 @@ namespace xw
         XPROPERTY(std::string, derived_type, icon);
         XPROPERTY(X_CASELESS_STR_ENUM(primary, success, info, warning, danger, ), derived_type, button_style);
 
+    protected:
+
+        xtogglebutton();
+
     private:
 
         void set_defaults();
     };
 
     using togglebutton = xmaterialize<xtogglebutton>;
+
+    using togglebutton_generator = xgenerator<xtogglebutton>;
 
     /********************************
      * xtogglebutton implementation *

--- a/include/xwidgets/xtransport.hpp
+++ b/include/xwidgets/xtransport.hpp
@@ -66,12 +66,6 @@ namespace xw
 
         using derived_type = D;
 
-        xtransport();
-        xtransport(const xtransport&);
-        xtransport(xtransport&&);
-        xtransport& operator=(const xtransport&);
-        xtransport& operator=(xtransport&&);
-
         derived_type& derived_cast() & noexcept;
         const derived_type& derived_cast() const & noexcept;
         derived_type derived_cast() && noexcept;
@@ -83,7 +77,13 @@ namespace xw
         void send(xeus::xjson&&) const;
 
     protected:
-        
+ 
+        xtransport();
+        xtransport(const xtransport&);
+        xtransport(xtransport&&);
+        xtransport& operator=(const xtransport&);
+        xtransport& operator=(xtransport&&);
+
         bool moved_from() const noexcept;
         void open();
         void close();
@@ -329,10 +329,10 @@ namespace xw
     inline void from_json(const xeus::xjson& j, xtransport<D>& o)
     {
         // TODO: directly convert from xjson
-        std::string prefixed_guid = j;
-        auto guid = prefixed_guid.substr(10).c_str();
-        auto& holder = get_transport_registry().find(guid);
-        o = holder.template get<D>();  // TODO: move?
+        //std::string prefixed_guid = j;
+        //auto guid = prefixed_guid.substr(10).c_str();
+        //auto& holder = get_transport_registry().find(guid);
+        //o = holder.template get<D>();  // TODO: move?
     }
 }
 

--- a/include/xwidgets/xvalid.hpp
+++ b/include/xwidgets/xvalid.hpp
@@ -28,11 +28,14 @@ namespace xw
         using base_type = xboolean<D>;
         using derived_type = D;
 
-        xvalid();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(std::string, derived_type, readout, "Invalid");
+
+    protected:
+
+        xvalid();
 
     private:
 
@@ -41,16 +44,11 @@ namespace xw
 
     using valid = xmaterialize<xvalid>;
 
+    using valid_generator = xgenerator<xvalid>;
+
     /*************************
      * xvalid implementation *
      *************************/
-
-    template <class D>
-    inline xvalid<D>::xvalid()
-        : base_type()
-    {
-        set_defaults();
-    }
 
     template <class D>
     inline xeus::xjson xvalid<D>::get_state() const
@@ -68,6 +66,13 @@ namespace xw
         base_type::apply_patch(patch);
 
         XOBJECT_SET_PROPERTY_FROM_PATCH(readout, patch)
+    }
+
+    template <class D>
+    inline xvalid<D>::xvalid()
+        : base_type()
+    {
+        set_defaults();
     }
 
     template <class D>

--- a/include/xwidgets/xwidget.hpp
+++ b/include/xwidgets/xwidget.hpp
@@ -28,11 +28,14 @@ namespace xw
         using base_type = xobject<D>;
         using derived_type = D;
 
-        xwidget();
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson& patch);
 
         XPROPERTY(::xw::layout, derived_type, layout);
+
+    protected:
+
+        xwidget();
 
     private:
 


### PR DESCRIPTION
- Make all the CRTP base constructors and affectation operators protected.
- Replace `make_widget<widget_type>` with a call to a constructor of `xgenerator<Xwidget_type>`
- Add a `using foobar_generator = xgenerator<xfoobar>` everywhere next to `using foobar = xmaterialize<xfoobar>` .
- Similarly for template widget types, `template <class T> using slider = xmaterialize<xslider, T>`.

The new syntax is

```cpp
auto s = xw::slider_generator<double>()
    .min(20.0)
    .max(50.0)
    .value(30.0)
    .finalize();
```
