### PR TITLE
Make link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ cmake -D CMAKE_INSTALL_PREFIX=your_install_prefix
 make install
 ```
 
-## Installing the dependencies
+## Dependencies
 
 All the dependencies of xeus-cling are available for the conda package manager. 
 
- - widgetsnbextension ~3.0.0
- - xeus >=0.6.0,0.7
- - xtl >=0.2.5,<0.3
- - xproperty >=0.3.0,<0.4
+| `xwidgets` | `widgetsnbextension`  |     `xtl`      | `xproperty`   | `xeus`       |
+|------------|-----------------------|----------------|---------------|--------------|
+|  master    |      ~3.0.0           |  >=0.2.5,<0.3  | >=0.4.0,<0.5  | >=0.6.0,<0.7 |
+|  0.2.0     |      ~3.0.0           |  >=0.2.5,<0.3  | >=0.3.0,<0.4  | >=0.6.0,<0.7 |
 
 ## License
 

--- a/include/xwidgets/xholder.hpp
+++ b/include/xwidgets/xholder.hpp
@@ -322,15 +322,11 @@ namespace xw
     template <template <class> class CRTP>
     xeus::xguid xholder<CRTP>::id() const
     {
-        if (p_holder != nullptr)
+        if (p_holder == nullptr)
         {
-            return p_holder->id();
+            throw std::runtime_error("The holder does not contain a widget");
         }
-        else
-        {
-            // TODO: throw?
-            return xeus::xguid();
-        }
+        return p_holder->id();
     }
 
     template <template <class> class CRTP>

--- a/include/xwidgets/xlink.hpp
+++ b/include/xwidgets/xlink.hpp
@@ -58,8 +58,6 @@ namespace xw
 
     protected:
 
-        xlink();
-
         template <class S, class T>
         xlink(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn);
 
@@ -97,13 +95,6 @@ namespace xw
     }
 
     template <class D>
-    inline xlink<D>::xlink()
-        : base_type()
-    {
-        set_defaults();
-    }
-
-    template <class D>
     template <class S, class T>
     inline xlink<D>::xlink(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn)
         : base_type()
@@ -120,18 +111,6 @@ namespace xw
     {
         this->_model_name() = "LinkModel";
         this->_model_module() = "@jupyter-widgets/controls";
-    }
-
-    template <class S, class T>
-    inline link make_link(xtransport<S>& s, std::string sn, xtransport<T>& t, std::string tn)
-    {
-        link l;
-        l.source().first = s;
-        l.source().second = sn;
-        l.target().first = t;
-        l.target().second = tn;
-        l.send_patch(l.get_state());
-        return l;
     }
 }
 

--- a/include/xwidgets/xtransport.hpp
+++ b/include/xwidgets/xtransport.hpp
@@ -246,6 +246,7 @@ namespace xw
         xeus::xjson data;
         data["method"] = "update";
         data["state"] = std::move(patch);
+        data["buffer_paths"] = xeus::xjson::array();
         m_comm.send(std::move(metadata), std::move(data));
     }
 

--- a/notebooks/xwidgets.ipynb
+++ b/notebooks/xwidgets.ipynb
@@ -849,7 +849,7 @@
    },
    "outputs": [],
    "source": [
-    "auto l = xw::make_link(s1, \"value\", s2, \"value\");"
+    "auto l = xw::link(s1, \"value\", s2, \"value\");"
    ]
   },
   {


### PR DESCRIPTION
- Update dependencies in README
- Better handling of empty handler in `xhandler::id()`.
- Simplify link widget to reflect the better constructor handling in xmaterialize (no need for `make_link`).
- Fixup issue in reply to state requests.