### PR TITLE
Use concrete_type for registering validators and observers in constructors

### DIFF
--- a/include/xwidgets/xcontroller.hpp
+++ b/include/xwidgets/xcontroller.hpp
@@ -62,7 +62,6 @@ namespace xw
 
         using base_type = xwidget<D>;
         using derived_type = D;
-        using base_type::base_type;
 
         xeus::xjson get_state() const;
         void apply_patch(const xeus::xjson&);
@@ -72,6 +71,7 @@ namespace xw
     protected:
 
         xcontroller_axis();
+        using base_type::base_type;
 
     private:
 
@@ -93,7 +93,6 @@ namespace xw
 
         using base_type = xwidget<D>;
         using derived_type = D;
-        using base_type::base_type;
 
         using xcontroller_axis_list_type = std::vector<xholder<xtransport>>;
         using xcontroller_button_list_type = std::vector<xholder<xtransport>>;
@@ -112,6 +111,7 @@ namespace xw
     protected:
 
         xcontroller();
+        using base_type::base_type;
 
     private:
 

--- a/include/xwidgets/xmaterialize.hpp
+++ b/include/xwidgets/xmaterialize.hpp
@@ -54,6 +54,25 @@ namespace xw
         xmaterialize<B, P...> finalize() &&;
     };
 
+    /******************
+     * xconcrete_type *
+     ******************/
+
+    template <class D>
+    struct xconcrete_type
+    {
+        using type = D;
+    };
+
+    template <template <class> class B, class... P>
+    struct xconcrete_type<xgenerator<B, P...>>
+    {
+        using type = xmaterialize<B, P...>;
+    };
+
+    template <class D>
+    using xconcrete_type_t = typename xconcrete_type<D>::type;
+
     /*******************************
      * xmaterialize implementation *
      *******************************/

--- a/include/xwidgets/xnumeral.hpp
+++ b/include/xwidgets/xnumeral.hpp
@@ -25,7 +25,6 @@ namespace xw
 
         using base_type = xnumber<D>;
         using derived_type = D;
-        using base_type::base_type;
 
         using value_type = typename base_type::value_type;
 
@@ -39,6 +38,7 @@ namespace xw
     protected:
 
         xnumeral();
+        using base_type::base_type;
 
     private:
 

--- a/include/xwidgets/xobject.hpp
+++ b/include/xwidgets/xobject.hpp
@@ -16,6 +16,7 @@
 
 #include "xproperty/xobserved.hpp"
 
+#include "xmaterialize.hpp"
 #include "xtransport.hpp"
 
 namespace xtl
@@ -65,7 +66,6 @@ namespace xw
 
         using base_type = xtransport<D>;
         using derived_type = D;
-        using base_type::base_type;
 
         using base_type::derived_cast;
 
@@ -80,6 +80,14 @@ namespace xw
         XPROPERTY(xtl::xoptional<std::string>, derived_type, _view_name, "WidgetView");
 
         using base_type::notify;
+
+    protected:
+
+        using base_type::base_type;
+        using concrete_type = xconcrete_type_t<D>; 
+
+        concrete_type* self();
+        const concrete_type* self() const;
     };
 
     /*******************************
@@ -96,17 +104,6 @@ namespace xw
     patch[#name] = this->name();
 
     template <class D>
-    inline void xobject<D>::apply_patch(const xeus::xjson& patch)
-    {
-        XOBJECT_SET_PROPERTY_FROM_PATCH(_model_module, patch);
-        XOBJECT_SET_PROPERTY_FROM_PATCH(_model_module_version, patch);
-        XOBJECT_SET_PROPERTY_FROM_PATCH(_model_name, patch);
-        XOBJECT_SET_PROPERTY_FROM_PATCH(_view_module, patch);
-        XOBJECT_SET_PROPERTY_FROM_PATCH(_view_module_version, patch);
-        XOBJECT_SET_PROPERTY_FROM_PATCH(_view_name, patch);
-    }
-
-    template <class D>
     inline xeus::xjson xobject<D>::get_state() const
     {
         xeus::xjson state;
@@ -119,6 +116,29 @@ namespace xw
         XOBJECT_SET_PATCH_FROM_PROPERTY(_view_name, state);
 
         return state;
+    }
+
+    template <class D>
+    inline void xobject<D>::apply_patch(const xeus::xjson& patch)
+    {
+        XOBJECT_SET_PROPERTY_FROM_PATCH(_model_module, patch);
+        XOBJECT_SET_PROPERTY_FROM_PATCH(_model_module_version, patch);
+        XOBJECT_SET_PROPERTY_FROM_PATCH(_model_name, patch);
+        XOBJECT_SET_PROPERTY_FROM_PATCH(_view_module, patch);
+        XOBJECT_SET_PROPERTY_FROM_PATCH(_view_module_version, patch);
+        XOBJECT_SET_PROPERTY_FROM_PATCH(_view_name, patch);
+    }
+
+    template <class D> 
+    inline auto xobject<D>::self() -> concrete_type*
+    {
+        return reinterpret_cast<concrete_type*>(this);
+    }
+
+    template <class D> 
+    inline auto xobject<D>::self() const -> const concrete_type*
+    {
+        return reinterpret_cast<const concrete_type*>(this);
     }
 }
 

--- a/include/xwidgets/xprogress.hpp
+++ b/include/xwidgets/xprogress.hpp
@@ -64,7 +64,6 @@ namespace xw
 
         using base_type = xnumber<D>;
         using derived_type = D;
-        using base_type::base_type;
 
         using value_type = typename base_type::value_type;
 
@@ -78,6 +77,7 @@ namespace xw
     protected:
 
         xprogress();
+        using base_type::base_type;
 
     private:
 

--- a/include/xwidgets/xselection.hpp
+++ b/include/xwidgets/xselection.hpp
@@ -146,7 +146,8 @@ namespace xw
     template <class D>
     inline void xselection<D>::setup_properties()
     {
-        this->template observe<decltype(value)>([](auto& owner) {
+        auto self = this->self();
+        self->template observe<decltype(self->value)>([](auto& owner) {
             const options_type& opt = owner._options_labels();
             auto new_index = std::find(opt.cbegin(), opt.cend(), owner.value()) - opt.cbegin();
             if (new_index != owner.index())
@@ -155,7 +156,7 @@ namespace xw
             }
         });
 
-        this->template observe<decltype(index)>([](auto& owner) {
+        self->template observe<decltype(self->index)>([](auto& owner) {
             auto new_value = owner._options_labels()[owner.index()];
             if (new_value != owner.value())
             {
@@ -163,7 +164,7 @@ namespace xw
             }
         });
 
-        this->template observe<decltype(_options_labels)>([](auto& owner) {
+        self->template observe<decltype(self->_options_labels)>([](auto& owner) {
             const options_type& opt = owner._options_labels();
             auto position = std::find(opt.cbegin(), opt.cend(), owner.value());
             if (position == opt.cend())
@@ -173,7 +174,7 @@ namespace xw
             owner.index = position - opt.cbegin();
         });
 
-        this->template validate<decltype(value)>([](auto& owner, auto& proposal) {
+        self->template validate<decltype(self->value)>([](auto& owner, auto& proposal) {
             const options_type& opt = owner._options_labels();
             if (std::find(opt.cbegin(), opt.cend(), proposal) == opt.cend())
             {
@@ -237,7 +238,8 @@ namespace xw
     template <class D>
     inline void xmultiple_selection<D>::setup_properties()
     {
-        this->template observe<decltype(value)>([](auto& owner) {
+        auto self = this->self();
+        self->template observe<decltype(self->value)>([](auto& owner) {
             const options_type& opt = owner._options_labels();
             index_type new_index;
             for (const auto& val : owner.value())
@@ -250,7 +252,7 @@ namespace xw
             }
         });
 
-        this->template observe<decltype(index)>([](auto& owner) {
+        self->template observe<decltype(self->index)>([](auto& owner) {
             value_type new_value;
             for (const auto& i : owner.index())
             {
@@ -262,11 +264,11 @@ namespace xw
             }
         });
 
-        this->template observe<decltype(_options_labels)>([](auto& owner) {
+        self->template observe<decltype(self->_options_labels)>([](auto& owner) {
             owner.index = index_type();
         });
 
-        this->template validate<decltype(value)>([](auto& owner, auto& proposal) {
+        self->template validate<decltype(self->value)>([](auto& owner, auto& proposal) {
             const options_type& opt = owner._options_labels();
             for (const auto& val : proposal)
             {

--- a/include/xwidgets/xselectionslider.hpp
+++ b/include/xwidgets/xselectionslider.hpp
@@ -133,7 +133,8 @@ namespace xw
             throw std::runtime_error("Empty collection passed to selection slider");
         }
 
-        this->template validate<decltype(this->_options_labels)>([](auto&, auto& proposal) {
+        auto self = this->self();
+        self->template validate<decltype(self->_options_labels)>([](auto&, auto& proposal) {
             if (proposal.empty())
             {
                 throw std::runtime_error("Empty collection passed to selection slider");
@@ -187,7 +188,8 @@ namespace xw
             throw std::runtime_error("Empty collection passed to selection slider");
         }
 
-        this->template validate<decltype(this->_options_labels)>([](auto&, auto& proposal) {
+        auto self = this->self();
+        self->template validate<decltype(self->_options_labels)>([](auto&, auto& proposal) {
             if (proposal.empty())
             {
                 throw std::runtime_error("Empty collection passed to selection slider");
@@ -206,7 +208,8 @@ namespace xw
             throw std::runtime_error("Empty collection passed to selection slider");
         }
 
-        this->template validate<decltype(this->_options_labels)>([](auto&, auto& proposal) {
+        auto self = this->self();
+        self->template validate<decltype(self->_options_labels)>([](auto&, auto& proposal) {
             if (proposal.empty())
             {
                 throw std::runtime_error("Empty collection passed to selection slider");

--- a/include/xwidgets/xslider.hpp
+++ b/include/xwidgets/xslider.hpp
@@ -192,7 +192,8 @@ namespace xw
     template <class D>
     inline void xslider<D>::setup_properties()
     {
-        this->template validate<decltype(this->value)>([](auto& owner, auto& proposal) {
+        auto self = this->self();
+        self->template validate<decltype(self->value)>([](auto& owner, auto& proposal) {
             if (proposal > owner.max())
             {
                 proposal = owner.max();
@@ -203,7 +204,7 @@ namespace xw
             }
         });
 
-        this->template validate<decltype(this->min)>([](auto& owner, auto& proposal) {
+        self->template validate<decltype(self->min)>([](auto& owner, auto& proposal) {
             if (proposal > owner.max())
             {
                 throw std::runtime_error("setting min > max");
@@ -214,7 +215,7 @@ namespace xw
             }
         });
 
-        this->template validate<decltype(this->max)>([](auto& owner, auto& proposal) {
+        self->template validate<decltype(self->max)>([](auto& owner, auto& proposal) {
             if (proposal < owner.min())
             {
                 throw std::runtime_error("setting max < min");


### PR DESCRIPTION
Another method instead of defining `self` would be to have the `concrete_type` typedef in all widgets alongside `derived_type` and make all the properties take a `concrete_type` instead of a `derived_type` template property.