### PR TITLE
Remove std pair to_json and from_json overloads

### DIFF
--- a/include/xwidgets/xlink.hpp
+++ b/include/xwidgets/xlink.hpp
@@ -15,23 +15,6 @@
 #include "xmaterialize.hpp"
 #include "xobject.hpp"
 
-namespace std
-{
-    template <class A, class B>
-    inline void to_json(xeus::xjson& j, const std::pair<A, B>& o)
-    {
-        j[0] = o.first;
-        j[1] = o.second;
-    }
-
-    template <class A, class B>
-    inline void from_json(const xeus::xjson& j, std::pair<A, B>& o)
-    {
-        o.first = j[0].get<A>();
-        o.second = j[1].get<B>();
-    }
-}
-
 namespace xw
 {
     /********************


### PR DESCRIPTION
After the update of `json` in xeus 0.8.2.