### PR TITLE
Fix cmake required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software. #
 ############################################################################
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.8)
 project(xwidgets)
 
 message(STATUS "Forcing tests build type to Release")


### PR DESCRIPTION
CMake fails on line CMakeLists.txt:109 with cmake before 3.8
See https://cmake.org/cmake/help/v3.8/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html
@JohanMabille 