### PR TITLE
Add mime bundle repr for xholders

### DIFF
--- a/docs/source/compilers.rst
+++ b/docs/source/compilers.rst
@@ -7,16 +7,42 @@
 Compiler workarounds
 ====================
 
-This page tracks the workarounds for the various compiler issues that we encountered in the development. This is mostly of interest for developers interested in contributing to xwidgets.
+This page tracks the workarounds for the various compiler issues that we
+encountered in the development. This is mostly of interest for developers
+interested in contributing to xwidgets.
 
 Visual Studio 2017 and ``__declspec(dllexport)``
 ------------------------------------------------
 
-In ``xwidgets.cpp`` a number of widget types are precompiled, in order to improve the just-in-time compilation time in the context of the cling C++ interpreter.
+In ``xwidgets.cpp`` a number of widget types are precompiled, in order to
+improve the just-in-time compilation time in the context of the cling C++
+interpreter.
 
-However, with Visual Studio 2017, the introduction of ``__declspec(dllexport)`` instructions for certain widget types causes compilation errors. This is the case for widget types that are used as properties for other widgets such as ``xlayout``` and style widgets.
+However, with Visual Studio 2017, the introduction of ``__declspec(dllexport)``
+instructions for certain widget types causes compilation errors. This is the
+case for widget types that are used as properties for other widgets such as
+``xlayout``` and style widgets.
+
+The upstream `MSVC issue`_  issue appears to have been solved with VS2017 15.7
+(Preview 3).
 
 Visual Studio and CRTP bases
 ----------------------------
 
-If we have ``template <class T> class Foo : public Bar<Foo<T>>``, then within the implementation of ``Foo ``, ``Bar`` should be a template, and not refer to ``Bar<Foo<T>>``. However, unlike GCC and Clang, Visual Studio incorrectly makes ``Bar`` refer to the fully specialized template type.
+If we have ``template <class T> class Foo : public Bar<Foo<T>>``, then within
+the implementation of ``Foo ``, ``Bar`` should be a template, and not refer to
+``Bar<Foo<T>>``. However, unlike GCC and Clang, Visual Studio incorrectly makes
+``Bar`` refer to the fully specialized template type.
+
+Cling and complex types
+-----------------------
+
+The rich mime-type rendering of xeus-cling relies upon cling's ability to
+provide a fully qualified type string for a value. This appears to be bugged
+for complex types in cling 0.5, where certain template parameter lack their
+namespace qualification. The we work around `Cling type string`_ bug for
+xholder by creating an alias template for `xtransport` in the general namespace
+in the case of cling.
+
+.. _`MSVC issue`: https://developercommunity.visualstudio.com/content/problem/208938/compilation-error-c2057-expected-constant-expressi.html
+.. _`Cling type string`: https://github.com/root-project/cling/issues/228

--- a/include/xwidgets/xmaterialize.hpp
+++ b/include/xwidgets/xmaterialize.hpp
@@ -11,6 +11,9 @@
 
 #include <utility>
 
+#include "xeus/xjson.hpp"
+#include "xwidgets_config.hpp"
+
 namespace xw
 {
     /****************************
@@ -150,13 +153,7 @@ namespace xw
 
     template <template <class> class B, class... P>
     inline xgenerator<B, P...>& xgenerator<B, P...>::operator=(xgenerator&&) = default;
-}
 
-#include "xeus/xjson.hpp"
-#include "xwidgets_config.hpp"
-
-namespace xw
-{
     /***********************************************************
      * Specialization of cling::printValue for Jupyter Widgets *
      ***********************************************************/


### PR DESCRIPTION
This seems to be impacted by https://github.com/vgvassilev/cling/issues/180#issuecomment-380125484 even with the fix in https://github.com/root-project/cling/pull/225.

```
input_line_15:2:59: error: use of undeclared identifier 'xtransport'; did you mean 'xw::xtransport'?
 mime_bundle_repr(*(*(std::__1::__vector_base<xw::xholder<xtransport>, std::__1::allocator<xw::xholder<xtransport> > >::value_type**)0x7ffee5a05c80));
                                                          ^~~~~~~~~~
                                                          xw::xtransport
/Users/scorlay/miniconda3/include/xwidgets/xtransport.hpp:85:11: note: 'xw::xtransport' declared here
    class xtransport
```

We had to add an alias template for xtransport in the general namespace for the case of cling.