### PR TITLE
shared holder api

### DIFF
--- a/include/xwidgets/xbox.hpp
+++ b/include/xwidgets/xbox.hpp
@@ -53,6 +53,9 @@ namespace xw
         void add(xtransport<T>&& w);
 
         template <class T>
+        enable_xtransport_t<T> add(std::shared_ptr<T> w);
+
+        template <class T>
         void remove(const xtransport<T>& w);
 
         void clear();
@@ -159,6 +162,22 @@ namespace xw
     inline void xbox<D>::add(xtransport<T>&& w)
     {
         this->children().emplace_back(make_owning_holder(std::move(w)));
+        xeus::xjson state;
+        xeus::buffer_sequence buffers;
+        set_patch_from_property(children, state, buffers);
+        this->send_patch(std::move(state), std::move(buffers));
+    }
+
+    template <class D>
+    template <class T>
+    inline enable_xtransport_t<T> xbox<D>::add(std::shared_ptr<T> w)
+    {
+#ifdef _MSC_VER
+        this->children().emplace_back(make_shared_holder<transport_type, T>(w));
+#else
+        this->children().emplace_back(make_shared_holder<xtransport, T>(w));
+#endif
+        //this->children().emplace_back(make_shared_holder<(w));
         xeus::xjson state;
         xeus::buffer_sequence buffers;
         set_patch_from_property(children, state, buffers);

--- a/include/xwidgets/xholder.hpp
+++ b/include/xwidgets/xholder.hpp
@@ -91,11 +91,8 @@ namespace xw
     template <template <class> class CRTP>
     xholder<CRTP> make_id_holder(xeus::xguid id);
 
-    template <template <class> class CRTP, class D, class... Args>
-    xholder<CRTP> make_shared_holder(Args&&... args);
-
     template <template <class> class CRTP, class D>
-    xholder<CRTP> make_shared_holder(CRTP<D>* ptr);
+    xholder<CRTP> make_shared_holder(std::shared_ptr<CRTP<D>> ptr);
 
     /*************************************
      * to_json and from_json declaration *
@@ -616,18 +613,12 @@ namespace xw
         };
     }
 
-    template <template <class> class CRTP, class D, class... Args>
-    inline xholder<CRTP> make_shared_holder(Args&&... args)
-    {
-        using impl_type = detail::xholder_shared<CRTP, D>;
-        return xholder<CRTP>(new impl_type(std::make_shared<D>(std::forward<Args>(args)...)));
-    }
-
     template <template <class> class CRTP, class D>
-    inline xholder<CRTP> make_shared_holder(CRTP<D>* ptr)
+    inline xholder<CRTP> make_shared_holder(std::shared_ptr<CRTP<D>> ptr)
     {
         using impl_type = detail::xholder_shared<CRTP, D>;
-        return xholder<CRTP>(new impl_type(ptr));
+        auto cast_ptr = std::static_pointer_cast<D>(ptr);
+        return xholder<CRTP>(new impl_type(cast_ptr));
     }
 
     /**********************************************************

--- a/include/xwidgets/xtransport.hpp
+++ b/include/xwidgets/xtransport.hpp
@@ -176,6 +176,15 @@ namespace xw
         xeus::xcomm m_comm;
     };
 
+    template <class T, class R = void>
+    struct enable_xtransport
+    {
+        using type = std::enable_if_t<std::is_base_of<xtransport<T>, T>::value, R>;
+    };
+
+    template <class T, class R = void>
+    using enable_xtransport_t = typename enable_xtransport<T, R>::type;
+
     /****************************************
      * to_json and from_json specialization *
      ****************************************/

--- a/test/test_xholder.cpp
+++ b/test/test_xholder.cpp
@@ -72,13 +72,12 @@ namespace xw
     {
         using map_type = std::map<std::string, xholder<xwidget>>;
         map_type hm1, hm2;
-        button_tester* b = new button_tester;
-        hm1["x"] = make_shared_holder<xwidget>(b);
+        hm1["x"] = make_shared_holder<xwidget, button_tester>(std::make_shared<button_tester>());
         hm2["x"] = hm1["x"];
         ASSERT_EQ(hm1["x"].id(), hm2["x"].id());
         ASSERT_EQ(button_tester::instance_count(), 1);
 
-        hm1["y"] = make_shared_holder<xwidget, button_tester>(4);;
+        hm1["y"] = make_shared_holder<xwidget, button_tester>(std::make_shared<button_tester>(4));
         hm2["y"] = hm1["y"];
         ASSERT_EQ(hm1["y"].template get<button_tester>().value(), hm2["y"].template get<button_tester>().value());
         ASSERT_EQ(button_tester::instance_count(), 2);

--- a/test/test_xwidgets.cpp
+++ b/test/test_xwidgets.cpp
@@ -46,6 +46,9 @@ namespace xw
         slider<double> s1, s2;
         hb.add(s1);
         hb.add(s2);
+
+        auto s3 = std::make_shared<slider<double>>();
+        hb.add(s3);
     }
 
     TEST(xwidgets, vbox)
@@ -54,6 +57,9 @@ namespace xw
         slider<double> s1, s2;
         vb.add(s1);
         vb.add(s2);
+
+        auto s3 = std::make_shared<slider<double>>();
+        vb.add(s3);
     }
 
     TEST(xwidgets, button_style)


### PR DESCRIPTION
This make the use of `xholder_shared` hidden, as discussed in #150 