### PR TITLE
parse integers in buffer paths for array indexing

### DIFF
--- a/include/xwidgets/xbinary.hpp
+++ b/include/xwidgets/xbinary.hpp
@@ -73,7 +73,14 @@ namespace xw
             const xeus::xjson* current = &patch;
             for (const auto& item : path)
             {
-                current = &((*current)[item]);
+                if (!current->is_array())
+                {
+                    current = &((*current)[item]);
+                }
+                else
+                {
+                    current = &(*current)[std::stoul(item)];
+                }
             }
             return *current;
         }
@@ -84,7 +91,14 @@ namespace xw
             xeus::xjson* current = &patch;
             for (const auto& item : path)
             {
-                current = &((*current)[item]);
+                if (!current->is_array())
+                {
+                    current = &((*current)[item]);
+                }
+                else
+                {
+                    current = &(*current)[std::stoul(item)];
+                }
             }
             return *current;
         }


### PR DESCRIPTION
This allows for the buffer paths in xvolume, e.g. `{"x", "0", "buffer"}` where the json looks like 

`{x: [ {buffer: ..., dtype: ... } ] };`